### PR TITLE
feat(email): add email retry queue with lease-based processing

### DIFF
--- a/supabase/functions/_shared/email-queue.ts
+++ b/supabase/functions/_shared/email-queue.ts
@@ -26,11 +26,11 @@ const LEASE_TTL_SECONDS = 1800;
 
 // Exponential backoff schedule (in seconds)
 const RETRY_DELAYS_SECONDS = [
-  60,       // 1 minute
-  300,      // 5 minutes
-  1800,     // 30 minutes
-  7200,     // 2 hours
-  43200,    // 12 hours
+  60, // 1 minute
+  300, // 5 minutes
+  1800, // 30 minutes
+  7200, // 2 hours
+  43200, // 12 hours
 ] as const;
 
 // Allowlist: only persist safe fields per template (never store secrets)
@@ -183,7 +183,9 @@ export async function fetchRetryableItems(
 }> {
   const { data, error } = await supabase
     .from("email_send_queue")
-    .select("id, event_id, recipient_email, template, params, attempts, max_attempts")
+    .select(
+      "id, event_id, recipient_email, template, params, attempts, max_attempts",
+    )
     .in("status", ["pending", "failed"])
     .lte("next_retry_at", new Date().toISOString())
     .order("next_retry_at", { ascending: true })
@@ -205,7 +207,8 @@ export async function markProcessing(
   queueId: string,
 ): Promise<ClaimResult> {
   const token = crypto.randomUUID();
-  const leaseExpiresAt = new Date(Date.now() + LEASE_TTL_SECONDS * 1000).toISOString();
+  const leaseExpiresAt = new Date(Date.now() + LEASE_TTL_SECONDS * 1000)
+    .toISOString();
 
   // Atomic claim: update only if still pending/failed, check row count
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- Email send queue module (`email-queue.ts`) with exponential backoff retry (1m→5m→30m→2h→12h)
- Lease-based claim tokens (30min TTL) preventing duplicate processing across workers
- Stale processing reclaim, dead letter after max attempts, PII sanitization in error messages
- Cron-triggered Edge Function (`retry-failed-emails`) with template dispatcher and verification code enrichment

## Files
| File | Lines | Description |
|------|-------|-------------|
| `_shared/email-queue.ts` | 342 | Queue module: enqueue, claim, markSent/Failed, reclaim |
| `_shared/email-queue_test.ts` | 469 | 30 test cases with mock Supabase client |
| `retry-failed-emails/index.ts` | 275 | Cron Edge Function with auth + lease flow |

## Test plan
- [ ] `deno test --no-check --allow-env --allow-net --allow-read _shared/email-queue_test.ts` passes (30 tests)
- [ ] CI pipeline green
- [ ] Deploy `retry-failed-emails` function after merge
- [ ] Configure `CRON_SECRET` in Supabase Secrets
- [ ] Set up pg_cron schedule (every 15 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)