### PR TITLE
alerts: reduce audit noise

### DIFF
--- a/.github/workflows/manus-audit-daily.yml
+++ b/.github/workflows/manus-audit-daily.yml
@@ -4,9 +4,8 @@
 name: Manus Audit (Daily)
 
 on:
-  schedule:
-    # 毎日 06:00 JST (21:00 UTC 前日)
-    - cron: '0 21 * * *'
+  # Deprecated: scheduled execution is handled by `manus-audit.yml` (Unified).
+  # Keep this workflow for manual runs / debugging only.
   workflow_dispatch:
     inputs:
       test_mode:

--- a/.github/workflows/manus-audit-monthly.yml
+++ b/.github/workflows/manus-audit-monthly.yml
@@ -4,9 +4,8 @@
 name: Manus Audit (Monthly)
 
 on:
-  schedule:
-    # 毎月1日 03:00 JST (18:00 UTC 前日)
-    - cron: '0 18 1 * *'
+  # Deprecated: scheduled execution is handled by `manus-audit.yml` (Unified).
+  # Keep this workflow for manual runs / debugging only.
   workflow_dispatch:
     # 手動実行も可能
 

--- a/.github/workflows/manus-audit-report.yml
+++ b/.github/workflows/manus-audit-report.yml
@@ -1,8 +1,8 @@
 name: Manus Audit (Report)
 
 on:
-  schedule:
-    - cron: '0 21 * * *'   # UTC21:00 = JST06:00
+  # Deprecated: scheduled audit execution is handled by `manus-audit.yml` (Unified).
+  # Keep this workflow for manual runs / debugging only.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/manus-audit-weekly.yml
+++ b/.github/workflows/manus-audit-weekly.yml
@@ -4,9 +4,8 @@
 name: Manus Audit (Weekly)
 
 on:
-  schedule:
-    # 毎週月曜日 09:00 JST (00:00 UTC)
-    - cron: '0 0 * * 1'
+  # Deprecated: scheduled execution is handled by `manus-audit.yml` (Unified).
+  # Keep this workflow for manual runs / debugging only.
   workflow_dispatch:
     # 手動実行も可能
 

--- a/.github/workflows/manus-audit.yml
+++ b/.github/workflows/manus-audit.yml
@@ -256,7 +256,10 @@ jobs:
           git push
 
       - name: Notify on failure
-        if: env.AUDIT_FAILED == 'true'
+        # Avoid duplicate alerts: the Supabase function posts the full audit report
+        # to Discord when the audit ran successfully (HTTP 200). This step is only
+        # for "audit execution failed" situations (non-200 or missing response).
+        if: env.AUDIT_FAILED == 'true' && env.AUDIT_HTTP_CODE != '200'
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_ADMIN_WEBHOOK_URL }}
           AUTO_FIX_APPLIED: ${{ steps.auto_fix.outputs.auto_fix_applied }}


### PR DESCRIPTION
アラート頻回の主因だった「重複スケジュール」と「重複通知」を削減。

- `.github/workflows/manus-audit-daily.yml` / `.github/workflows/manus-audit-weekly.yml` / `.github/workflows/manus-audit-monthly.yml` / `.github/workflows/manus-audit-report.yml` の `schedule` を廃止（手動実行専用）
  - スケジュール実行は `.github/workflows/manus-audit.yml` (Unified) に集約
- Unified の Discord 通知は「HTTP が非 200 のときだけ」送る
  - 監査実行が成功して監査結果にエラーがある場合は、Supabase 側が出す詳細な監査レポート通知に任せて二重通知を避ける

これで同時刻に複数の監査が走って Discord に多重投稿される状態を止めます。
