### PR TITLE
fix: route Manus alerts to system monitor

### DIFF
--- a/.github/workflows/auto-repair-line.yml
+++ b/.github/workflows/auto-repair-line.yml
@@ -229,9 +229,14 @@ jobs:
           SUCCESS: ${{ steps.result.outputs.success }}
           MESSAGE: ${{ steps.result.outputs.message }}
           ISSUE_TYPE: ${{ inputs.issue_type }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Repair notification cannot be delivered."
+            exit 1
+          fi
+
           MANUS_URL="${MANUS_TASK_URL:-}"
 
           if [ "$SUCCESS" = "true" ]; then
@@ -251,7 +256,7 @@ jobs:
           # JSONエスケープしてDiscordに通知
           SAFE_MESSAGE=$(echo "$MESSAGE" | jq -Rs '.' | sed 's/^"//;s/"$//')
 
-          curl -X POST "$DISCORD_WEBHOOK_URL" \
+          curl --fail --show-error --silent -X POST "$DISCORD_SYSTEM_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{
               \"embeds\": [{
@@ -265,4 +270,5 @@ jobs:
                 ],
                 \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
               }]
-            }" || true
+            }" \
+            --output /dev/null

--- a/.github/workflows/manus-audit.yml
+++ b/.github/workflows/manus-audit.yml
@@ -362,7 +362,7 @@ jobs:
         # for "audit execution failed" situations (non-200 or missing response).
         if: env.AUDIT_FAILED == 'true' && env.AUDIT_HTTP_CODE != '200'
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
           AUTO_FIX_APPLIED: ${{ steps.auto_fix.outputs.auto_fix_applied }}
           MANUS_TASK_URL: ${{ steps.auto_fix.outputs.manus_task_url }}
         run: |
@@ -379,11 +379,14 @@ jobs:
             MODE_NAME="月次"
           fi
 
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            curl -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "🚨 **Manus'"$MODE_NAME"'監査が失敗しました**\n対応: '"$AUTO_FIX_STATUS"'\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+          if [ -z "${DISCORD_SYSTEM_WEBHOOK:-}" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Audit failure notification cannot be delivered."
+            exit 1
           fi
+          curl --fail --show-error --silent -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "🚨 **Manus'"$MODE_NAME"'監査が失敗しました**\n対応: '"$AUTO_FIX_STATUS"'\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}' \
+            --output /dev/null
 
       - name: Finalize audit status
         if: always()

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 医療AI教育プラットフォーム「Cursorvers」のLINE Bot + Stripe決済 + Discord連携システム
 
-[![CI Tests](https://github.com/mo666-med/cursorvers_line_free_dev/actions/workflows/test-line-webhook.yml/badge.svg)](https://github.com/mo666-med/cursorvers_line_free_dev/actions/workflows/test-line-webhook.yml)
+[![CI Tests](https://github.com/mo666-med/cursorvers_line_free_dev/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/mo666-med/cursorvers_line_free_dev/actions/workflows/ci-tests.yml)
 [![Deploy](https://github.com/mo666-med/cursorvers_line_free_dev/actions/workflows/deploy-supabase.yml/badge.svg)](https://github.com/mo666-med/cursorvers_line_free_dev/actions/workflows/deploy-supabase.yml)
 
 ## 概要
@@ -100,7 +100,7 @@ supabase functions deploy line-webhook --project-ref haaxgwyimoqzzxzdaeep
 ```
 .
 ├── .github/workflows/           # GitHub Actions
-│   ├── test-line-webhook.yml    # CI/CD + Auto-Fix
+│   ├── ci-tests.yml             # CI/CD
 │   ├── deploy-supabase.yml      # Edge Functions デプロイ
 │   ├── manus-audit-daily.yml    # 日次監査
 │   ├── manus-progress.yml       # Manus進捗ハンドラ
@@ -164,9 +164,8 @@ supabase functions deploy line-webhook --project-ref haaxgwyimoqzzxzdaeep
 
 | ワークフロー | トリガー | 説明 |
 |-------------|---------|------|
-| `test-line-webhook.yml` | push/PR | テスト + Auto-Fix |
+| `ci-tests.yml` | push/PR | テスト・Lint・型チェック |
 | `deploy-supabase.yml` | push to main | Edge Functionsデプロイ |
-| `ci-tests.yml` | PR | 型チェック・Lint |
 
 ### 監査・自動化
 
@@ -212,7 +211,7 @@ MANUS_API_KEY=...
 ```bash
 SUPABASE_ACCESS_TOKEN=...
 SUPABASE_PROJECT_ID=haaxgwyimoqzzxzdaeep
-DISCORD_ADMIN_WEBHOOK_URL=...
+DISCORD_SYSTEM_WEBHOOK=...
 ```
 
 ---

--- a/docs/MANUS_AUTOMATION.md
+++ b/docs/MANUS_AUTOMATION.md
@@ -203,7 +203,7 @@ git push origin main
 | Secret名 | 説明 | 取得方法 |
 |---------|------|---------|
 | `MANUS_GITHUB_TOKEN` | GitHub自動プッシュ用 | [GitHub Settings](https://github.com/settings/tokens) |
-| `DISCORD_ADMIN_WEBHOOK_URL` | Discord通知用 | Discord Server Settings |
+| `DISCORD_SYSTEM_WEBHOOK` | Manus/system alert Discord通知用 | Discord Server Settings |
 | `SUPABASE_ACCESS_TOKEN` | Supabase CLI 用 | Supabase Dashboard / CLI |
 | `SUPABASE_PROJECT_ID` | 対象 project ref | Supabase Dashboard |
 | `MANUS_AUDIT_API_KEY` | 監査 Edge Function 認証 | repo / env policy |
@@ -237,7 +237,7 @@ git push origin main
 
 ### Discord通知が届かない
 
-1. `DISCORD_ADMIN_WEBHOOK_URL`が設定されているか確認
+1. `DISCORD_SYSTEM_WEBHOOK`が設定されているか確認
 2. Webhook URLが有効か確認（Discord Server Settings）
 3. ワークフローログでエラーを確認
 

--- a/docs/REQUIRED_SECRETS.md
+++ b/docs/REQUIRED_SECRETS.md
@@ -13,7 +13,7 @@
 | Plane | 置き場所 | 用途 | 例 |
 |---|---|---|---|
 | GitHub Org/Repo/Environment Secrets | GitHub Actions | 監査、デプロイ、workflow 実行 | `MANUS_GITHUB_TOKEN`, `MANUS_AUDIT_API_KEY`, `SUPABASE_ACCESS_TOKEN` |
-| Platform Runtime Secrets | Supabase / Cloudflare / Vercel | 本番実行時の `Deno.env.get(...)` / runtime env | `SUPABASE_SERVICE_ROLE_KEY`, `LINE_CHANNEL_ACCESS_TOKEN`, `MANUS_API_KEY` |
+| Platform Runtime Secrets | Supabase / Cloudflare / Vercel | 本番実行時の `Deno.env.get(...)` / runtime env | `SUPABASE_SERVICE_ROLE_KEY`, `LINE_CHANNEL_ACCESS_TOKEN`, `MANUS_API_KEY`, `DISCORD_ADMIN_SECRET` |
 | Local bootstrap | shell env / repo外 env file | one-shot import only | `export MANUS_GITHUB_TOKEN=...` |
 
 ---
@@ -23,7 +23,7 @@
 ### 1. Discord Webhook関連
 
 #### `DISCORD_ADMIN_WEBHOOK_URL`
-- **用途**: システム監査、エラー通知、日次レポート送信
+- **用途**: 管理者向けの個別通知。Manus/system alert には使わない
 - **設定値**: Discord Webhookから取得（形式: `https://discord.com/api/webhooks/{webhook_id}/{token}`）
 - **使用箇所**:
   - `.github/workflows/manus-audit-daily.yml`
@@ -32,11 +32,13 @@
   - `.github/workflows/replenish-cards.yml`
   - その他多数のワークフロー
 
-#### `DISCORD_SYSTEM_WEBHOOK` (オプション)
-- **用途**: システム点検スクリプト（`scripts/daily-check.sh`）での通知
-- **設定値**: `DISCORD_ADMIN_WEBHOOK_URL`と同じ値を推奨
+#### `DISCORD_SYSTEM_WEBHOOK` (必須)
+- **用途**: system alert / Manus監査 / 自動修繕 / code-fixer 専用通知。`scripts/daily-check.sh` / `scripts/daily-check-improved.sh` / health-check 等でも使用
+- **設定値**: `#system-monitor` (channel ID `1443582135322804285`) の専用 Discord Webhook
+- **禁止事項**: `DISCORD_ADMIN_WEBHOOK_URL` と同じ値を使わないこと。system alert は専用 webhook に分離すること。
 - **使用箇所**:
   - `scripts/daily-check.sh`
+  - `scripts/daily-check-improved.sh`
   - Supabase Edge Functions（health-check等）
 
 ---
@@ -125,8 +127,21 @@
 - `LINE_CHANNEL_SECRET`
 - `MANUS_API_KEY`
 - `DISCORD_SYSTEM_WEBHOOK`
+- `DISCORD_ADMIN_SECRET`
+- `DISCORD_STATUS_ALLOWED_CHANNEL_IDS`
 
 必要に応じて GitHub Actions から deploy 時に同期してよいですが、実行時の正本は Supabase 側です。
+
+### Discord admin/debug policy
+
+- `DISCORD_ADMIN_SECRET`
+  - `discord-status`, `discord-relay` の admin/debug endpoint 用
+  - `x-admin-secret` でのみ送ること
+  - `SUPABASE_SERVICE_ROLE_KEY` や generic `apikey` を代用しないこと
+- `DISCORD_STATUS_ALLOWED_CHANNEL_IDS`
+  - `discord-status /send-message` の許可 channel の CSV
+  - 未設定時は `#system-monitor` (channel ID `1443582135322804285`) のみ許可
+  - `discord-status /create-webhook` は policy で禁止
 
 ## 🔧 設定方法
 
@@ -171,6 +186,8 @@ Supabase runtime へは:
 supabase secrets set LINE_CHANNEL_ACCESS_TOKEN=... --project-ref haaxgwyimoqzzxzdaeep
 supabase secrets set MANUS_API_KEY=... --project-ref haaxgwyimoqzzxzdaeep
 supabase secrets set DISCORD_SYSTEM_WEBHOOK=... --project-ref haaxgwyimoqzzxzdaeep
+supabase secrets set DISCORD_ADMIN_SECRET=... --project-ref haaxgwyimoqzzxzdaeep
+supabase secrets set DISCORD_STATUS_ALLOWED_CHANNEL_IDS=1443582135322804285 --project-ref haaxgwyimoqzzxzdaeep
 ```
 
 ---
@@ -209,7 +226,7 @@ gh run list --workflow=manus-audit-daily.yml --limit 1
 ## 📝 トラブルシューティング
 
 ### Discord通知が届かない
-- `DISCORD_ADMIN_WEBHOOK_URL`が正しく設定されているか確認
+- `DISCORD_SYSTEM_WEBHOOK`が正しく設定されているか確認
 - Webhook URLの有効性をテスト:
   ```bash
   curl -X POST "https://discord.com/api/webhooks/..." \

--- a/supabase/functions/manus-audit-line-daily-brief/index.ts
+++ b/supabase/functions/manus-audit-line-daily-brief/index.ts
@@ -52,8 +52,7 @@ const log = createLogger("manus-audit");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const MANUS_AUDIT_API_KEY = Deno.env.get("MANUS_AUDIT_API_KEY");
-const DISCORD_ADMIN_WEBHOOK_URL = Deno.env.get("DISCORD_ADMIN_WEBHOOK_URL");
-const DISCORD_MAINT_WEBHOOK_URL = Deno.env.get("DISCORD_MAINT_WEBHOOK_URL");
+const DISCORD_SYSTEM_WEBHOOK = Deno.env.get("DISCORD_SYSTEM_WEBHOOK");
 const MANUS_WEBHOOK_URL = Deno.env.get("MANUS_WEBHOOK_URL");
 const LANDING_PAGE_URL = Deno.env.get("LANDING_PAGE_URL") ?? "";
 // LINE_CHANNEL_ACCESS_TOKEN は checkLineBotHealth() 内で直接取得
@@ -272,14 +271,15 @@ Deno.serve(async (req) => {
       }
     }
 
-    // Send notifications ONLY when remediation was triggered
-    // 修繕が実行された場合のみ通知（異常検出のみでは通知しない）
-    const shouldNotify = result.remediation?.triggered === true;
+    // report mode is an explicit maintenance-log request; other modes notify
+    // only when remediation actually ran.
+    const shouldNotify = isReportMode || result.remediation?.triggered === true;
 
     if (shouldNotify) {
-      log.info("Sending notification - remediation was triggered", {
+      log.info("Sending audit notification", {
         errorCount: result.summary.errorCount,
         warningCount: result.summary.warningCount,
+        isReportMode,
         remediationTriggered: result.remediation?.triggered,
       });
 
@@ -291,14 +291,15 @@ Deno.serve(async (req) => {
           }),
           sendDiscordNotification(result, {
             force: true,
-            webhookUrl: DISCORD_MAINT_WEBHOOK_URL,
+            webhookUrl: DISCORD_SYSTEM_WEBHOOK,
             audience: "maintenance",
+            requireDelivery: true,
           }),
         ]);
       } else {
         await sendDiscordNotification(result, {
           force: true,
-          webhookUrl: DISCORD_ADMIN_WEBHOOK_URL,
+          webhookUrl: DISCORD_SYSTEM_WEBHOOK,
           audience: "admin",
         });
       }

--- a/supabase/functions/manus-audit-line-daily-brief/notification.ts
+++ b/supabase/functions/manus-audit-line-daily-brief/notification.ts
@@ -211,9 +211,15 @@ export async function sendDiscordNotification(
     force?: boolean;
     webhookUrl?: string | undefined;
     audience?: NotificationAudience;
+    requireDelivery?: boolean;
   },
 ): Promise<void> {
-  const { force = false, webhookUrl, audience = "admin" } = options;
+  const {
+    force = false,
+    webhookUrl,
+    audience = "admin",
+    requireDelivery = false,
+  } = options;
 
   if (
     !force &&
@@ -226,23 +232,33 @@ export async function sendDiscordNotification(
   }
 
   if (!webhookUrl) {
-    log.warn("Discord webhook URL not configured, skipping notification");
+    const message = "Discord webhook URL not configured";
+    if (requireDelivery) {
+      throw new Error(message);
+    }
+    log.warn(`${message}, skipping notification`);
     return;
   }
 
   const message = buildNotificationMessage(result, audience);
 
   try {
-    await fetch(webhookUrl, {
+    const response = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ content: message }),
     });
+    if (!response.ok) {
+      throw new Error(`Discord webhook returned HTTP ${response.status}`);
+    }
     log.info("Discord notification sent", { audience });
   } catch (error) {
     log.error("Failed to send Discord notification", {
       error: error instanceof Error ? error.message : String(error),
     });
+    if (requireDelivery) {
+      throw error;
+    }
   }
 }
 

--- a/supabase/functions/manus-audit-line-daily-brief/notification_test.ts
+++ b/supabase/functions/manus-audit-line-daily-brief/notification_test.ts
@@ -1,8 +1,11 @@
 /**
  * notification.ts ユニットテスト
  */
-import { assertEquals } from "std-assert";
-import { buildNotificationMessage } from "./notification.ts";
+import { assertEquals, assertRejects } from "std-assert";
+import {
+  buildNotificationMessage,
+  sendDiscordNotification,
+} from "./notification.ts";
 import type { AuditResult } from "./types.ts";
 
 // テスト用のベースとなるAuditResult
@@ -306,5 +309,67 @@ Deno.test("notification - buildNotificationMessage", async (t) => {
     });
     const message = buildNotificationMessage(result, "manus");
     assertEquals(message.includes("LINE登録システム"), true);
+  });
+});
+
+Deno.test("notification - sendDiscordNotification delivery guarantees", async (t) => {
+  await t.step("throws when required delivery has no webhook", async () => {
+    await assertRejects(
+      () =>
+        sendDiscordNotification(createBaseResult(), {
+          force: true,
+          audience: "maintenance",
+          requireDelivery: true,
+        }),
+      Error,
+      "Discord webhook URL not configured",
+    );
+  });
+
+  await t.step("throws when required delivery receives non-2xx", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(new Response("gone", { status: 404 }))) as typeof fetch;
+    try {
+      await assertRejects(
+        () =>
+          sendDiscordNotification(createBaseResult(), {
+            force: true,
+            webhookUrl: "https://discord.example.invalid/webhook",
+            audience: "maintenance",
+            requireDelivery: true,
+          }),
+        Error,
+        "Discord webhook returned HTTP 404",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  await t.step("posts to configured webhook when required", async () => {
+    const originalFetch = globalThis.fetch;
+    const calls: Array<{ url: string; body: string }> = [];
+    globalThis.fetch = ((input: URL | RequestInfo, init?: RequestInit) => {
+      calls.push({
+        url: String(input),
+        body: String(init?.body ?? ""),
+      });
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as typeof fetch;
+    try {
+      await sendDiscordNotification(createBaseResult(), {
+        force: true,
+        webhookUrl: "https://discord.example.invalid/webhook",
+        audience: "maintenance",
+        requireDelivery: true,
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    assertEquals(calls.length, 1);
+    assertEquals(calls[0]?.url, "https://discord.example.invalid/webhook");
+    assertEquals(calls[0]?.body.includes("Manus監査レポート"), true);
   });
 });

--- a/supabase/functions/manus-code-fixer/index.ts
+++ b/supabase/functions/manus-code-fixer/index.ts
@@ -106,7 +106,10 @@ interface ErrorItem {
   error: string;
 }
 
-const REQUIRED_ENV_VARS = ["MANUS_FIXER_API_KEY"] as const;
+const REQUIRED_ENV_VARS = [
+  "MANUS_FIXER_API_KEY",
+  "DISCORD_SYSTEM_WEBHOOK",
+] as const;
 
 const getEnv = (name: (typeof REQUIRED_ENV_VARS)[number]): string => {
   const value = Deno.env.get(name);
@@ -119,10 +122,7 @@ const getEnv = (name: (typeof REQUIRED_ENV_VARS)[number]): string => {
 import { createLogger } from "../_shared/logger.ts";
 
 const MANUS_FIXER_API_KEY = getEnv("MANUS_FIXER_API_KEY");
-const DISCORD_WEBHOOK_URL = Deno.env.get("DISCORD_MANUS_WEBHOOK_URL") ??
-  Deno.env.get("DISCORD_WEBHOOK_URL") ??
-  Deno.env.get("DISCORD_ADMIN_WEBHOOK_URL") ??
-  Deno.env.get("DISCORD_SYSTEM_WEBHOOK");
+const DISCORD_WEBHOOK_URL = getEnv("DISCORD_SYSTEM_WEBHOOK");
 const MANUS_GITHUB_TOKEN = Deno.env.get("MANUS_GITHUB_TOKEN");
 const GITHUB_TOKEN = Deno.env.get("GITHUB_TOKEN");
 const GITHUB_API_BASE = Deno.env.get("GITHUB_API_BASE") ??

--- a/supabase/functions/manus-intelligent-repair/index.ts
+++ b/supabase/functions/manus-intelligent-repair/index.ts
@@ -49,7 +49,7 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL") ?? "";
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ??
   "";
 const MANUS_REPAIR_API_KEY = Deno.env.get("MANUS_REPAIR_API_KEY");
-const DISCORD_ADMIN_WEBHOOK_URL = Deno.env.get("DISCORD_ADMIN_WEBHOOK_URL");
+const DISCORD_SYSTEM_WEBHOOK = Deno.env.get("DISCORD_SYSTEM_WEBHOOK");
 const MANUS_GITHUB_TOKEN = Deno.env.get("MANUS_GITHUB_TOKEN");
 const GITHUB_TOKEN = Deno.env.get("GITHUB_TOKEN");
 const GITHUB_REPO = Deno.env.get("GITHUB_REPO") ??
@@ -938,10 +938,10 @@ async function sendNotification(
   }
 
   // Discord通知（タイムアウト5秒、失敗しても続行）
-  if (channels.includes("discord") && DISCORD_ADMIN_WEBHOOK_URL) {
+  if (channels.includes("discord") && DISCORD_SYSTEM_WEBHOOK) {
     try {
       await fetchWithTimeout(
-        DISCORD_ADMIN_WEBHOOK_URL,
+        DISCORD_SYSTEM_WEBHOOK,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- route Manus audit, repair, and code-fixer notifications through DISCORD_SYSTEM_WEBHOOK
- remove legacy Manus/admin webhook fallback for system alerts
- make report-mode Discord delivery fail explicitly when the system webhook is missing or non-2xx
- update docs and add notification delivery tests

## Verification
- deno fmt --check supabase/functions/manus-audit-line-daily-brief/index.ts supabase/functions/manus-audit-line-daily-brief/notification.ts supabase/functions/manus-audit-line-daily-brief/notification_test.ts supabase/functions/manus-intelligent-repair/index.ts supabase/functions/manus-code-fixer/index.ts
- deno test --allow-env supabase/functions/manus-audit-line-daily-brief/notification_test.ts supabase/functions/manus-audit-line-daily-brief/auth_test.ts supabase/functions/manus-audit-line-daily-brief/types-utils_test.ts
- actionlint -shellcheck= .github/workflows/manus-audit.yml .github/workflows/auto-repair-line.yml
- git diff --check