### PR TITLE
fix: enforce system webhook for maintenance alerts

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,17 +7,45 @@ on:
   push:
     branches: [main]
     paths:
-      - 'supabase/functions/**/*.ts'
-      - 'supabase/functions/deno.json'
-      - 'scripts/**/*.ts'
-      - '.github/workflows/ci-tests.yml'
+      - "supabase/functions/**/*.ts"
+      - "supabase/functions/deno.json"
+      - "scripts/**/*.ts"
+      - ".github/workflows/manus-audit.yml"
+      - ".github/workflows/auto-repair-line.yml"
+      - ".github/workflows/manus-progress.yml"
+      - ".github/workflows/manus-code-fixer.yml"
+      - ".github/workflows/edge-function-monitor.yml"
+      - ".github/workflows/e2e-pipeline-monitor.yml"
+      - ".github/workflows/discord-forum-sync.yml"
+      - ".github/workflows/replenish-cards.yml"
+      - ".github/workflows/stripe-consistency-check-cron.yml"
+      - ".github/workflows/metrics-export.yml"
+      - ".github/workflows/line-daily-brief-cron.yml"
+      - ".github/workflows/stats-exporter-cron.yml"
+      - ".github/workflows/sec-brief-cron.yml"
+      - ".github/workflows/sync-line-cards.yml"
+      - ".github/workflows/ci-tests.yml"
   pull_request:
     branches: [main]
     paths:
-      - 'supabase/functions/**/*.ts'
-      - 'supabase/functions/deno.json'
-      - 'scripts/**/*.ts'
-      - '.github/workflows/ci-tests.yml'
+      - "supabase/functions/**/*.ts"
+      - "supabase/functions/deno.json"
+      - "scripts/**/*.ts"
+      - ".github/workflows/manus-audit.yml"
+      - ".github/workflows/auto-repair-line.yml"
+      - ".github/workflows/manus-progress.yml"
+      - ".github/workflows/manus-code-fixer.yml"
+      - ".github/workflows/edge-function-monitor.yml"
+      - ".github/workflows/e2e-pipeline-monitor.yml"
+      - ".github/workflows/discord-forum-sync.yml"
+      - ".github/workflows/replenish-cards.yml"
+      - ".github/workflows/stripe-consistency-check-cron.yml"
+      - ".github/workflows/metrics-export.yml"
+      - ".github/workflows/line-daily-brief-cron.yml"
+      - ".github/workflows/stats-exporter-cron.yml"
+      - ".github/workflows/sec-brief-cron.yml"
+      - ".github/workflows/sync-line-cards.yml"
+      - ".github/workflows/ci-tests.yml"
   workflow_dispatch:
 
 # 並列実行を制限

--- a/.github/workflows/discord-forum-sync.yml
+++ b/.github/workflows/discord-forum-sync.yml
@@ -107,13 +107,16 @@ jobs:
       - name: Notify on failure
         if: failure()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            curl -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "⚠️ **Discord Forum Sync ワークフローが失敗しました**\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Forum sync failure notification cannot be delivered."
+            exit 1
           fi
+
+          curl -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "⚠️ **Discord Forum Sync ワークフローが失敗しました**\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
 
       - name: Upload workflow logs
         if: always()

--- a/.github/workflows/e2e-pipeline-monitor.yml
+++ b/.github/workflows/e2e-pipeline-monitor.yml
@@ -215,10 +215,14 @@ jobs:
       - name: Notify on Issues
         if: steps.report.outputs.overall != 'healthy'
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. E2E monitor notification cannot be delivered."
+            exit 1
+          fi
+
+          TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
 
             if [ "${{ steps.report.outputs.overall }}" = "error" ]; then
               COLOR=15158332  # Red
@@ -228,7 +232,7 @@ jobs:
               TITLE="E2E Pipeline Monitor: Warnings"
             fi
 
-            curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+            curl -s -X POST "$DISCORD_SYSTEM_WEBHOOK" \
               -H "Content-Type: application/json" \
               -d "{
                 \"embeds\": [{
@@ -244,7 +248,6 @@ jobs:
                   \"footer\": {\"text\": \"E2E Pipeline Monitor | ${TIMESTAMP}\"}
                 }]
               }"
-          fi
 
       - name: Summary
         run: |

--- a/.github/workflows/line-daily-brief-cron.yml
+++ b/.github/workflows/line-daily-brief-cron.yml
@@ -6,18 +6,14 @@ name: LINE Daily Brief
 on:
   schedule:
     # 金曜 JST 12:00 (UTC 03:00) — 毎週発火、ジョブ内で偶数ISOweekのみ実行
-    - cron: '0 3 * * 5'
+    - cron: "0 3 * * 5"
   workflow_dispatch:
     inputs:
       source_type:
-        description: 'Card source type (belief or note). Leave empty for auto.'
+        description: "Card source type (belief or note). Leave empty for auto."
         required: false
-        default: ''
-        type: choice
-        options:
-          - ''
-          - belief
-          - note
+        default: ""
+        type: string
 
 concurrency:
   group: line-daily-brief
@@ -117,13 +113,16 @@ jobs:
       - name: Notify on failure
         if: failure()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            curl -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "⚠️ **LINE Daily Brief ワークフローが失敗しました**\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Daily brief failure notification cannot be delivered."
+            exit 1
           fi
+
+          curl -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "⚠️ **LINE Daily Brief ワークフローが失敗しました**\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
 
       - name: Upload workflow logs
         if: always()

--- a/.github/workflows/manus-progress.yml
+++ b/.github/workflows/manus-progress.yml
@@ -295,11 +295,11 @@ jobs:
       - name: Notify Discord
         if: always()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
-            echo "Discord webhook not configured, skipping notification"
-            exit 0
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Progress notification cannot be delivered."
+            exit 1
           fi
 
           STATUS="${{ steps.parse.outputs.status }}"
@@ -321,7 +321,7 @@ jobs:
               ;;
           esac
 
-          curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+          curl --fail --show-error --silent -X POST "$DISCORD_SYSTEM_WEBHOOK" \
             -H "Content-Type: application/json" \
             -d "{
               \"content\": \"$EMOJI **Manus Progress**: $EVENT_TYPE\\nTask: \`$TASK_ID\`\\nStatus: \`$STATUS\`\"

--- a/.github/workflows/metrics-export.yml
+++ b/.github/workflows/metrics-export.yml
@@ -137,12 +137,16 @@ jobs:
       - name: Notify Discord
         if: always()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d")
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::notice::DISCORD_SYSTEM_WEBHOOK not set; skipping metrics export notification."
+            exit 0
+          fi
 
-            curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+          TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d")
+
+          curl -s -X POST "$DISCORD_SYSTEM_WEBHOOK" \
               -H "Content-Type: application/json" \
               -d "{
                 \"embeds\": [{
@@ -157,4 +161,3 @@ jobs:
                   \"url\": \"https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\"
                 }]
               }"
-          fi

--- a/.github/workflows/replenish-cards.yml
+++ b/.github/workflows/replenish-cards.yml
@@ -82,14 +82,17 @@ jobs:
       - name: Notify Discord on success
         if: success() && inputs.dry_run != 'true'
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
-            curl -s -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d "{\"embeds\": [{\"title\": \"✅ AI カード自動補充完了\", \"color\": 5763719, \"fields\": [{\"name\": \"テーマ\", \"value\": \"${{ inputs.themes || 'tax,career,general' }}\", \"inline\": true}, {\"name\": \"生成数/テーマ\", \"value\": \"${{ inputs.count || '20' }}\", \"inline\": true}, {\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}], \"footer\": {\"text\": \"AI Card Generator\"}}]}"
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::notice::DISCORD_SYSTEM_WEBHOOK not set; skipping card replenishment success notification."
+            exit 0
           fi
+
+          TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
+          curl -s -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\": [{\"title\": \"✅ AI カード自動補充完了\", \"color\": 5763719, \"fields\": [{\"name\": \"テーマ\", \"value\": \"${{ inputs.themes || 'tax,career,general' }}\", \"inline\": true}, {\"name\": \"生成数/テーマ\", \"value\": \"${{ inputs.count || '20' }}\", \"inline\": true}, {\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}], \"footer\": {\"text\": \"AI Card Generator\"}}]}"
 
       # ========================================
       # 失敗時: Manus分析 → GitHub Issue作成
@@ -186,17 +189,20 @@ jobs:
       - name: Notify Discord on failure
         if: always() && steps.generate.outcome == 'failure'
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
-            MANUS_URL="${{ steps.manus.outputs.task_url }}"
-            MANUS_INFO=""
-            if [ -n "$MANUS_URL" ]; then
-              MANUS_INFO=", {\"name\": \"Manus分析\", \"value\": \"[View](${MANUS_URL})\", \"inline\": true}"
-            fi
-
-            curl -s -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d "{\"embeds\": [{\"title\": \"❌ AI カード自動補充失敗（3回リトライ後）\", \"color\": 15158332, \"description\": \"GitHub Issue を作成しました。Manus が原因分析中です。\", \"fields\": [{\"name\": \"テーマ\", \"value\": \"${{ inputs.themes || 'tax,career,general' }}\", \"inline\": true}, {\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}, {\"name\": \"ログ\", \"value\": \"[View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": true}${MANUS_INFO}], \"footer\": {\"text\": \"AI Card Generator\"}}]}"
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Card replenishment failure notification cannot be delivered."
+            exit 1
           fi
+
+          TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
+          MANUS_URL="${{ steps.manus.outputs.task_url }}"
+          MANUS_INFO=""
+          if [ -n "$MANUS_URL" ]; then
+            MANUS_INFO=", {\"name\": \"Manus分析\", \"value\": \"[View](${MANUS_URL})\", \"inline\": true}"
+          fi
+
+          curl -s -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\": [{\"title\": \"❌ AI カード自動補充失敗（3回リトライ後）\", \"color\": 15158332, \"description\": \"GitHub Issue を作成しました。Manus が原因分析中です。\", \"fields\": [{\"name\": \"テーマ\", \"value\": \"${{ inputs.themes || 'tax,career,general' }}\", \"inline\": true}, {\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}, {\"name\": \"ログ\", \"value\": \"[View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": true}${MANUS_INFO}], \"footer\": {\"text\": \"AI Card Generator\"}}]}"

--- a/.github/workflows/sec-brief-cron.yml
+++ b/.github/workflows/sec-brief-cron.yml
@@ -45,11 +45,13 @@ jobs:
       - name: Notify on failure
         if: failure()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            curl -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d '{"content": "⚠️ **sec-brief-cron ワークフローが失敗しました**\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Security brief failure notification cannot be delivered."
+            exit 1
           fi
 
+          curl -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{"content": "⚠️ **sec-brief-cron ワークフローが失敗しました**\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'

--- a/.github/workflows/stats-exporter-cron.yml
+++ b/.github/workflows/stats-exporter-cron.yml
@@ -3,8 +3,8 @@ name: Stats Exporter to Google Sheets
 on:
   schedule:
     # 12時間ごとに実行（00:00 JST と 12:00 JST）
-    - cron: '0 15,3 * * *'  # 00:00 JST (15:00 UTC) と 12:00 JST (03:00 UTC)
-  workflow_dispatch:  # 手動実行も可能
+    - cron: "0 15,3 * * *" # 00:00 JST (15:00 UTC) と 12:00 JST (03:00 UTC)
+  workflow_dispatch: # 手動実行も可能
 
 jobs:
   export-stats:
@@ -21,19 +21,19 @@ jobs:
         run: |
           exec > >(tee -a "$LOG_FILE") 2>&1
           echo "📊 Exporting stats to Google Sheets..."
-          
+
           # stats-exporter Supabase Functionを呼び出し
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "${{ vars.SUPABASE_URL }}/functions/v1/stats-exporter?mode=full" \
             -H "Authorization: Bearer ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
             -H "Content-Type: application/json")
-          
+
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
           BODY=$(echo "$RESPONSE" | sed '$d')
-          
+
           echo "HTTP Status: $HTTP_CODE"
           echo "Response: $BODY"
-          
+
           if [ "$HTTP_CODE" -eq 200 ]; then
             echo "✅ Stats exported successfully"
           else
@@ -43,15 +43,21 @@ jobs:
 
       - name: Notify Discord on failure
         if: failure()
+        env:
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}" ]; then
-            curl -X POST "${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "embeds": [{
-                  "title": "❌ Stats Exporter Failed",
-                  "description": "Google Sheetsへの統計情報エクスポートが失敗しました。",
-                  "color": 15158332,
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Stats exporter failure notification cannot be delivered."
+            exit 1
+          fi
+
+          curl -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "❌ Stats Exporter Failed",
+                "description": "Google Sheetsへの統計情報エクスポートが失敗しました。",
+                "color": 15158332,
                   "fields": [
                     {
                       "name": "Repository",
@@ -72,16 +78,21 @@ jobs:
                   "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
                 }]
               }'
-          fi
 
       - name: Notify Discord on success
         if: success()
+        env:
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}" ]; then
-            curl -X POST "${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "embeds": [{
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::notice::DISCORD_SYSTEM_WEBHOOK not set; skipping stats exporter success notification."
+            exit 0
+          fi
+
+          curl -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
                   "title": "✅ Stats Exported",
                   "description": "Google Sheetsへの統計情報エクスポートが完了しました。",
                   "color": 3066993,
@@ -100,7 +111,6 @@ jobs:
                   "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
                 }]
               }'
-          fi
 
       - name: Upload workflow logs
         if: always()

--- a/.github/workflows/stripe-consistency-check-cron.yml
+++ b/.github/workflows/stripe-consistency-check-cron.yml
@@ -50,14 +50,20 @@ jobs:
 
       - name: Notify Discord on failure
         if: failure()
+        env:
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}" ]; then
-            curl -X POST "${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}" \
-              -H "Content-Type: application/json" \
-              -d '{
-                "embeds": [{
-                  "title": "❌ Stripe Consistency Check Failed",
-                  "description": "Stripeイベントとmembers更新の整合性チェックが失敗しました。",
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. Stripe consistency failure notification cannot be delivered."
+            exit 1
+          fi
+
+          curl -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "❌ Stripe Consistency Check Failed",
+                "description": "Stripeイベントとmembers更新の整合性チェックが失敗しました。",
                   "color": 15158332,
                   "fields": [
                     {
@@ -79,7 +85,6 @@ jobs:
                   "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
                 }]
               }'
-          fi
 
       - name: Upload workflow logs
         if: always()

--- a/.github/workflows/sync-line-cards.yml
+++ b/.github/workflows/sync-line-cards.yml
@@ -105,23 +105,29 @@ jobs:
       - name: Notify on success
         if: success() && steps.sync.outputs.mode == 'live' && steps.sync.outputs.cards_inserted != '0'
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
-            curl -s -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d "{\"embeds\": [{\"title\": \"LINEカード同期完了\", \"color\": 5763719, \"fields\": [{\"name\": \"新規追加\", \"value\": \"${{ steps.sync.outputs.cards_inserted }}枚\", \"inline\": true}, {\"name\": \"重複スキップ\", \"value\": \"${{ steps.sync.outputs.cards_skipped }}枚\", \"inline\": true}, {\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}], \"footer\": {\"text\": \"Obsidian Vault Sync\"}}]}"
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::notice::DISCORD_SYSTEM_WEBHOOK not set; skipping LINE card sync success notification."
+            exit 0
           fi
+
+          TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
+          curl -s -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\": [{\"title\": \"LINEカード同期完了\", \"color\": 5763719, \"fields\": [{\"name\": \"新規追加\", \"value\": \"${{ steps.sync.outputs.cards_inserted }}枚\", \"inline\": true}, {\"name\": \"重複スキップ\", \"value\": \"${{ steps.sync.outputs.cards_skipped }}枚\", \"inline\": true}, {\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}], \"footer\": {\"text\": \"Obsidian Vault Sync\"}}]}"
 
       - name: Notify on failure
         if: failure()
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_SYSTEM_WEBHOOK || secrets.DISCORD_ADMIN_WEBHOOK_URL }}
+          DISCORD_SYSTEM_WEBHOOK: ${{ secrets.DISCORD_SYSTEM_WEBHOOK }}
         run: |
-          if [ -n "$DISCORD_WEBHOOK_URL" ]; then
-            TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
-            curl -s -X POST "$DISCORD_WEBHOOK_URL" \
-              -H "Content-Type: application/json" \
-              -d "{\"embeds\": [{\"title\": \"LINEカード同期失敗\", \"description\": \"Obsidian Vault同期でエラーが発生しました\", \"color\": 15158332, \"fields\": [{\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}, {\"name\": \"ログ\", \"value\": \"[View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": true}], \"footer\": {\"text\": \"Obsidian Vault Sync\"}}]}"
+          if [ -z "$DISCORD_SYSTEM_WEBHOOK" ]; then
+            echo "::error::DISCORD_SYSTEM_WEBHOOK not set. LINE card sync failure notification cannot be delivered."
+            exit 1
           fi
+
+          TIMESTAMP=$(TZ=Asia/Tokyo date +"%Y-%m-%d %H:%M JST")
+          curl -s -X POST "$DISCORD_SYSTEM_WEBHOOK" \
+            -H "Content-Type: application/json" \
+            -d "{\"embeds\": [{\"title\": \"LINEカード同期失敗\", \"description\": \"Obsidian Vault同期でエラーが発生しました\", \"color\": 15158332, \"fields\": [{\"name\": \"日時\", \"value\": \"${TIMESTAMP}\", \"inline\": true}, {\"name\": \"ログ\", \"value\": \"[View Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\", \"inline\": true}], \"footer\": {\"text\": \"Obsidian Vault Sync\"}}]}"

--- a/supabase/functions/_shared/alert.ts
+++ b/supabase/functions/_shared/alert.ts
@@ -5,8 +5,7 @@
 
 // 環境変数は実行時に読み込む（テスト対応）
 function getDiscordWebhook(): string | undefined {
-  return Deno.env.get("DISCORD_ALERT_WEBHOOK") ??
-    Deno.env.get("DISCORD_SYSTEM_WEBHOOK");
+  return Deno.env.get("DISCORD_SYSTEM_WEBHOOK");
 }
 
 export interface NotifyOptions {

--- a/supabase/functions/_shared/alert_test.ts
+++ b/supabase/functions/_shared/alert_test.ts
@@ -13,12 +13,10 @@ import {
 // 環境変数未設定時のテスト
 // ========================================
 
-Deno.test("notifyDiscord skips notification when DISCORD_ALERT_WEBHOOK is not set", async () => {
-  const originalAlertWebhook = Deno.env.get("DISCORD_ALERT_WEBHOOK");
+Deno.test("notifyDiscord skips notification when DISCORD_SYSTEM_WEBHOOK is not set", async () => {
   const originalSystemWebhook = Deno.env.get("DISCORD_SYSTEM_WEBHOOK");
 
   try {
-    Deno.env.delete("DISCORD_ALERT_WEBHOOK");
     Deno.env.delete("DISCORD_SYSTEM_WEBHOOK");
 
     const result = await notifyDiscord({
@@ -31,9 +29,6 @@ Deno.test("notifyDiscord skips notification when DISCORD_ALERT_WEBHOOK is not se
     assertEquals(result.attempts, 0);
     assertEquals(result.error, "Webhook not configured");
   } finally {
-    if (originalAlertWebhook) {
-      Deno.env.set("DISCORD_ALERT_WEBHOOK", originalAlertWebhook);
-    }
     if (originalSystemWebhook) {
       Deno.env.set("DISCORD_SYSTEM_WEBHOOK", originalSystemWebhook);
     }

--- a/supabase/functions/_shared/manus-system-discord-routing-policy_test.ts
+++ b/supabase/functions/_shared/manus-system-discord-routing-policy_test.ts
@@ -1,0 +1,80 @@
+import { assertEquals } from "std-assert";
+
+const REPO_ROOT = new URL("../../../", import.meta.url);
+
+const MANUS_SYSTEM_POLICY_FILES = [
+  ".github/workflows/manus-audit.yml",
+  ".github/workflows/auto-repair-line.yml",
+  ".github/workflows/manus-progress.yml",
+  ".github/workflows/manus-code-fixer.yml",
+  ".github/workflows/edge-function-monitor.yml",
+  ".github/workflows/e2e-pipeline-monitor.yml",
+  ".github/workflows/discord-forum-sync.yml",
+  ".github/workflows/replenish-cards.yml",
+  ".github/workflows/stripe-consistency-check-cron.yml",
+  ".github/workflows/metrics-export.yml",
+  ".github/workflows/line-daily-brief-cron.yml",
+  ".github/workflows/stats-exporter-cron.yml",
+  ".github/workflows/sec-brief-cron.yml",
+  ".github/workflows/sync-line-cards.yml",
+  "supabase/functions/_shared/alert.ts",
+  "supabase/functions/manus-audit-line-daily-brief/index.ts",
+  "supabase/functions/manus-intelligent-repair/index.ts",
+  "supabase/functions/manus-code-fixer/index.ts",
+] as const;
+
+const FORBIDDEN_WEBHOOK_KEYS = [
+  "DISCORD_ALERT_WEBHOOK",
+  "DISCORD_ADMIN_WEBHOOK_URL",
+  "DISCORD_MAINT_WEBHOOK_URL",
+  "DISCORD_MANUS_WEBHOOK_URL",
+  "DISCORD_WEBHOOK_URL",
+] as const;
+
+const DISCORD_NOTIFICATION_FILES = [
+  ".github/workflows/manus-audit.yml",
+  ".github/workflows/auto-repair-line.yml",
+  ".github/workflows/manus-progress.yml",
+  ".github/workflows/edge-function-monitor.yml",
+  ".github/workflows/e2e-pipeline-monitor.yml",
+  ".github/workflows/discord-forum-sync.yml",
+  ".github/workflows/replenish-cards.yml",
+  ".github/workflows/stripe-consistency-check-cron.yml",
+  ".github/workflows/metrics-export.yml",
+  ".github/workflows/line-daily-brief-cron.yml",
+  ".github/workflows/stats-exporter-cron.yml",
+  ".github/workflows/sec-brief-cron.yml",
+  ".github/workflows/sync-line-cards.yml",
+  "supabase/functions/_shared/alert.ts",
+  "supabase/functions/manus-audit-line-daily-brief/index.ts",
+  "supabase/functions/manus-intelligent-repair/index.ts",
+  "supabase/functions/manus-code-fixer/index.ts",
+] as const;
+
+async function readRepoFile(path: string): Promise<string> {
+  return await Deno.readTextFile(new URL(path, REPO_ROOT));
+}
+
+Deno.test("manus/system policy files do not reference legacy or generic Discord webhook keys", async () => {
+  for (const file of MANUS_SYSTEM_POLICY_FILES) {
+    const content = await readRepoFile(file);
+    for (const forbidden of FORBIDDEN_WEBHOOK_KEYS) {
+      assertEquals(
+        content.includes(forbidden),
+        false,
+        `${file} must not reference ${forbidden}`,
+      );
+    }
+  }
+});
+
+Deno.test("manus/system Discord notification surfaces require DISCORD_SYSTEM_WEBHOOK", async () => {
+  for (const file of DISCORD_NOTIFICATION_FILES) {
+    const content = await readRepoFile(file);
+    assertEquals(
+      content.includes("DISCORD_SYSTEM_WEBHOOK"),
+      true,
+      `${file} must reference DISCORD_SYSTEM_WEBHOOK`,
+    );
+  }
+});

--- a/supabase/functions/manus-code-fixer/index.ts
+++ b/supabase/functions/manus-code-fixer/index.ts
@@ -122,7 +122,7 @@ const getEnv = (name: (typeof REQUIRED_ENV_VARS)[number]): string => {
 import { createLogger } from "../_shared/logger.ts";
 
 const MANUS_FIXER_API_KEY = getEnv("MANUS_FIXER_API_KEY");
-const DISCORD_WEBHOOK_URL = getEnv("DISCORD_SYSTEM_WEBHOOK");
+const DISCORD_SYSTEM_WEBHOOK = getEnv("DISCORD_SYSTEM_WEBHOOK");
 const MANUS_GITHUB_TOKEN = Deno.env.get("MANUS_GITHUB_TOKEN");
 const GITHUB_TOKEN = Deno.env.get("GITHUB_TOKEN");
 const GITHUB_API_BASE = Deno.env.get("GITHUB_API_BASE") ??
@@ -438,7 +438,7 @@ async function sendDiscordNotification(
   request: FixRequest,
   result: FixResult,
 ): Promise<void> {
-  if (!DISCORD_WEBHOOK_URL) {
+  if (!DISCORD_SYSTEM_WEBHOOK) {
     log.warn("Discord webhook URL not configured, skipping notification");
     return;
   }
@@ -480,7 +480,7 @@ async function sendDiscordNotification(
   }
 
   try {
-    await fetch(DISCORD_WEBHOOK_URL, {
+    await fetch(DISCORD_SYSTEM_WEBHOOK, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ content: message.trim() }),


### PR DESCRIPTION
## Summary
- remove admin/generic Discord webhook fallback from active maintenance workflows
- make shared alert helper use only DISCORD_SYSTEM_WEBHOOK
- add CI-covered routing policy test for Manus/system maintenance notification surfaces

## Verification
- cd supabase/functions && deno test --allow-env --allow-net --allow-read _shared/manus-system-discord-routing-policy_test.ts _shared/alert_test.ts
- cd supabase/functions && deno check _shared/alert.ts _shared/alert_test.ts _shared/manus-system-discord-routing-policy_test.ts manus-code-fixer/index.ts
- actionlint -ignore 'shellcheck reported issue' .github/workflows/e2e-pipeline-monitor.yml .github/workflows/discord-forum-sync.yml .github/workflows/replenish-cards.yml .github/workflows/stripe-consistency-check-cron.yml .github/workflows/metrics-export.yml .github/workflows/line-daily-brief-cron.yml .github/workflows/stats-exporter-cron.yml .github/workflows/sec-brief-cron.yml .github/workflows/sync-line-cards.yml .github/workflows/manus-progress.yml .github/workflows/ci-tests.yml
- git diff --check

## Known unrelated issue
- deno task test:functions still fails in supabase/functions/_shared/discord_test.ts strict typing errors that predate this routing hardening.